### PR TITLE
tests: strip inherited identity/trajectory env from run-all.sh (#117)

### DIFF
--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -12,6 +12,14 @@
 
 set -uo pipefail
 
+# Hermetic by design (laude-institute/headlong#117): running the suite from inside
+# an activated identity must not leak its identity/trajectory env into the tests.
+# tools/identity re-roots to the caller's live .identities when IDENTITY_NAME and
+# IDENTITY_DIR point at an active identity, so `identity new` inside a test would write
+# there instead of the test's own temp app dir. Every test unsets or exports its own
+# values, so the suite itself needs none of these.
+unset IDENTITY_NAME IDENTITY_DIR MEM_DIR SKILLS_DIR SKILLS_KERNEL_DIR TRAJ_ID TRAJ_DIR ROOT_TRAJ_ID
+
 HERE="$(cd "$(dirname "$0")" && pwd)"
 pattern="${1:-}"
 


### PR DESCRIPTION
## Symptom
Running `tests/run-all.sh` from inside an **activated identity** leaks `IDENTITY_NAME`/`IDENTITY_DIR` into the tests. `tools/identity` re-roots to the caller's live `.identities` in that state (see `tools/identity:20-22`), so `identity new` inside a test writes the `ada`/`alpha`/`chatexit*`/`default` fixtures into the **live** identity instead of the test's own temp app dir. This is the 2026-09-10 incident (#117): six stray identities left in a live `.identities`.

## Fix
`run-all.sh` unsets the identity + trajectory env at the top, so the suite is hermetic no matter what activated it. The unset list matches exactly the `deactivate` unset (`tools/identity:428`) plus the `TRAJ_ID`/`TRAJ_DIR`/`ROOT_TRAJ_ID` an activated wake exports. Every individual test unsets or exports its own values, so none of these are needed by the suite itself.

```bash
unset IDENTITY_NAME IDENTITY_DIR MEM_DIR SKILLS_DIR SKILLS_KERNEL_DIR TRAJ_ID TRAJ_DIR ROOT_TRAJ_ID
```

## Verification (ran from inside an activated identity)
- **Before (upstream)**: running the suite with `IDENTITY_NAME`/`IDENTITY_DIR` set wrote `ada`, `alpha`, `chatexit*`, `default` into the live `.identities`.
- **After (this PR)**: full suite run with the identity-activated env → **only `custos`** remains in the live `.identities`; `ada`/`alpha`/`chatexit*`/`default`/`testfoo` all land in each test's own temp `HOME`. No leak.
- Pre-existing red: `test_monolith_wake_sections.sh` has 2 failures (`matched memory listed`, `state file has related_prev`) that fail identically **standalone under a clean `env -i`** at this commit — unrelated to this change (my diff touches only `run-all.sh`). Flagged, not fixed here.